### PR TITLE
change calendar initilization by Gregorian

### DIFF
--- a/CalculateCalendarLogic/CalculateCalendarLogic.swift
+++ b/CalculateCalendarLogic/CalculateCalendarLogic.swift
@@ -20,8 +20,8 @@ public enum Weekday: Int {
     case sun, mon, tue, wed, thu, fri, sat
 
     init?(year: Int, month: Int, day: Int) {
-        let cal = Calendar.current as NSCalendar
-        guard let date = cal.date(era: AD, year: year, month: month, day: day, hour: 0, minute: 0, second: 0, nanosecond: 0) else { return nil }
+        let cal = Calendar(identifier: .gregorian)
+        guard let date = cal.date(from: DateComponents(era: AD, year: year, month: month, day: day, hour: 0, minute: 0, second: 0, nanosecond: 0))  else { return nil }
         let weekdayNum = cal.component(.weekday, from: date)  // 1:日曜日 ～ 7:土曜日
         self.init(rawValue: weekdayNum - 1)
     }
@@ -159,9 +159,8 @@ public struct CalculateCalendarLogic {
      */
     public func judgeJapaneseHoliday(year: Int, month: Int, day: Int) -> Bool {
         
-        let cal = Calendar.current as NSCalendar
-        guard let date = cal.date(
-            era: AD, year: year, month: month, day: day, hour: 0, minute: 0, second: 0, nanosecond: 0) else {
+        let cal = Calendar(identifier: .gregorian)
+        guard let date = cal.date(from: DateComponents(calendar: cal, era: AD, year: year, month: month, day: day)) else {
             fatalError() // FIXME: throwにしたほうがよい？
         }
         let weekdayNum = cal.component(.weekday, from: date) // 1:日曜日 ～ 7:土曜日
@@ -405,10 +404,10 @@ public struct CalculateCalendarLogic {
      * 指定した年の敬老の日を調べる
      */
     internal func oldPeopleDay(year: Int) -> Int {
-        let cal = Calendar.current as NSCalendar
+        let cal = Calendar(identifier: .gregorian)
         
         func dateFromDay(day: Int) -> NSDate? {
-            return cal.date(era: AD, year: year, month: 9, day: day, hour: 0, minute: 0, second: 0, nanosecond: 0) as NSDate?
+            return cal.date(from: DateComponents(era: AD, year: year, month: 9, day: day, hour: 0, minute: 0, second: 0, nanosecond: 0)) as NSDate?
         }
         
         func weekdayAndDayFromDate(date: NSDate) -> (weekday: Int, day: Int) {

--- a/handMadeCalendarAdvance.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/handMadeCalendarAdvance.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>


### PR DESCRIPTION
【このPRが解決すること】
端末のカレンダー設定が「グレゴリ暦」以外でも、日本の祝日が正しく判定されるようになる

